### PR TITLE
Update grid layout in RolesPage

### DIFF
--- a/src/pages/RolesPage.vue
+++ b/src/pages/RolesPage.vue
@@ -250,8 +250,10 @@ h2 {
 
 #role-categories {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
   row-gap: 3%;
+  column-gap: 3%;
+  grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+  grid-auto-rows: 1fr;
 }
 
 .category-card {


### PR DESCRIPTION
The grid layout for the role categories section in RolesPage.vue has been updated. Previously, there were three equal-width columns. Now, the number of columns automatically adjusts based on the size of the viewport with a minimum width of 500px per column. Additionally, gaps between the columns have been added.